### PR TITLE
Fix pasting from clipboard on macOS

### DIFF
--- a/contrib-clipboard/init.zsh
+++ b/contrib-clipboard/init.zsh
@@ -37,7 +37,7 @@ done
 
 function putbuffer {
   if [[ "$OSTYPE" == darwin* ]]; then
-    zle copy-region-as-kill "$(pbcopy)"
+    zle copy-region-as-kill "$(pbpaste)"
   elif [[ "$OSTYPE" == cygwin* ]]; then
     zle copy-region-as-kill "$(cat /dev/clipboard)"
   elif (( $+commands[xclip] )); then


### PR DESCRIPTION
`pbcopy` does not print the content of the clipboard on macOS, it should be `pbpaste`.