### PR TITLE
[kubernetes] Changed the way of customizing cluster formatting

### DIFF
--- a/contrib-kubernetes/init.zsh
+++ b/contrib-kubernetes/init.zsh
@@ -48,5 +48,5 @@ kbn () {
   kubectl config set-context $(kubectl config current-context) --namespace=$1
 }
 
-# Cluster name formatting
-zstyle ':prezto:module:contrib-kubernetes' prod-clusters-default '^(?!.*dev).*$'
+# name formatting
+zstyle ':prezto:module:contrib-kubernetes' dev-clusters-default 'dev'

--- a/contrib-prompt/functions/prompt_sorin_contrib_setup
+++ b/contrib-prompt/functions/prompt_sorin_contrib_setup
@@ -46,7 +46,7 @@ function prompt_sorin_contrib_async_callback {
 
       zstyle -s ':prezto:module:contrib-kubernetes' prod-clusters prod_regexp
 
-      if [ -n "$prod_regexp" ]
+      if [[ -n "$prod_regexp" ]]
       then
         if [[ -n "$(echo "$_k8s_cluster" | grep -E "$prod_regexp")" ]]
         then
@@ -56,7 +56,7 @@ function prompt_sorin_contrib_async_callback {
         fi
       else
         zstyle -s ':prezto:module:contrib-kubernetes' dev-clusters dev_regexp
-        if [ -z "$dev_regexp" ]
+        if [[ -z "$dev_regexp" ]]
         then
           zstyle -s ':prezto:module:contrib-kubernetes' dev-clusters-default dev_regexp
         fi

--- a/contrib-prompt/functions/prompt_sorin_contrib_setup
+++ b/contrib-prompt/functions/prompt_sorin_contrib_setup
@@ -45,18 +45,31 @@ function prompt_sorin_contrib_async_callback {
       _prompt_k8s="%B("
 
       zstyle -s ':prezto:module:contrib-kubernetes' prod-clusters prod_regexp
-      if [[ -z "$prod_regexp" ]]
-      then
-        zstyle -s ':prezto:module:contrib-kubernetes' prod-clusters-default prod_regexp
-      fi
 
-      if [[ -n "$(echo "$_k8s_cluster" | grep -P "$prod_regexp")" ]]
+      if [ -n "$prod_regexp" ]
       then
-        _prompt_k8s+='%F{1}'
+        if [[ -n "$(echo "$_k8s_cluster" | grep -E "$prod_regexp")" ]]
+        then
+            _prompt_k8s+="%F{1}"
+        else
+            _prompt_k8s+="%F{7}"
+        fi
       else
-        _prompt_k8s+='%F{7}'
-      fi
-        _prompt_k8s+="$_k8s_cluster%f"
+        zstyle -s ':prezto:module:contrib-kubernetes' dev-clusters dev_regexp
+        if [ -z "$dev_regexp" ]
+        then
+          zstyle -s ':prezto:module:contrib-kubernetes' dev-clusters-default dev_regexp
+        fi
+
+        if [[ -n "$(echo "$_k8s_cluster" | grep -E "$dev_regexp")" ]]
+           then
+               _prompt_k8s+="%F{7}"
+           else
+               _prompt_k8s+="%F{1}"
+           fi
+        fi
+
+      _prompt_k8s+="$_k8s_cluster%f"
       if [[ -n "$_k8s_ns" ]]
       then
         _prompt_k8s+="|%F{4}$_k8s_ns%p%f"


### PR DESCRIPTION
In order to simplify the regular expression to be used to differenciate
prod clusters from dev clusters and remove the grep -P occurence, we
changed the configuration like this:
- if prod-clusters is defined, then clusters which have at least one
matching part with the regular expression will be colorized as red, the
others will be colorized as white.
- if prod-clusters is not defined and dev-clusters is defined, then
clusters which have at least one matching part with the regular
expression will be colorized as white, the others will be colorized as
red.
- if either prod-clusters and dev-clusters aren't defined then
dev-clusters-default will be used as dev-clusters.

This way, we removed the need of using perl regular expression and makes
the prompt compatible with macos and bsd-like distros and users
now have two ways of defining their clusters.

Moreover, this feature will have minimal impact on existing users.