### PR TITLE
Add Powerlevel10k theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "enhancd/external"]
 	path = enhancd/external
 	url = https://github.com/b4b4r07/enhancd.git
+[submodule "contrib-prompt/external/powerlevel10k"]
+	path = contrib-prompt/external/powerlevel10k
+	url = https://github.com/romkatv/powerlevel10k.git

--- a/contrib-prompt/functions/prompt_powerlevel10k_setup
+++ b/contrib-prompt/functions/prompt_powerlevel10k_setup
@@ -1,0 +1,1 @@
+../external/powerlevel10k/powerlevel10k.zsh-theme


### PR DESCRIPTION
[Powerlevel10k](https://github.com/romkatv/powerlevel10k) is a 10-100 faster reimplementation of the popular Powerlevel9k theme. It renders the same prompt when given the same configuration options but does it faster. If an existing user of powerlevel9k replaces `zstyle :prezto:module:prompt theme powerlevel9k` in their `.zpreztorc` with `zstyle :prezto:module:prompt theme powerlevel10k`, their prompt will get blazingly fast while still looking the same as before.

Obligatory screenshot:

![Powerlevel10k](https://raw.githubusercontent.com/romkatv/powerlevel10k/master/demo.png)

Tested on pristine Ubuntu:

```zsh
docker run -e LANG=C.UTF-8 -e LC_ALL=C.UTF-8 -e TERM=$TERM -it --rm ubuntu bash -uexc '
  apt update && apt install -y zsh git
  git clone --recursive https://github.com/sorin-ionescu/prezto.git ~/.zprezto
  zsh -ec "
    setopt EXTENDED_GLOB
    for rcfile in ~/.zprezto/runcoms/^README.md(.N); do
      ln -s \$rcfile ~/.\${rcfile:t}
    done
  "
  echo "
    # Your prompt configuration goes here.
    POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(root_indicator dir_writable dir vcs)
    POWERLEVEL9K_RIGHT_PROMPT_ELEMENTS=(status command_execution_time background_jobs time)
    POWERLEVEL9K_PROMPT_ON_NEWLINE=true
  " >>~/.zshrc
  cd ~/.zprezto
  git clone -b powerlevel10k https://github.com/romkatv/prezto-contrib.git contrib
  cd contrib
  git submodule init
  git submodule update
  echo "
    zstyle :prezto:load pmodule contrib-prompt prompt
    zstyle :prezto:module:prompt theme powerlevel10k
  " >>~/.zpreztorc
  zsh -i
'
```
