### PR TITLE
Delete prompt_powerlevel10k_setup

### DIFF
--- a/contrib-prompt/functions/prompt_powerlevel10k_setup
+++ b/contrib-prompt/functions/prompt_powerlevel10k_setup
@@ -1,1 +1,0 @@
-../external/powerlevel10k/powerlevel10k.zsh-theme


### PR DESCRIPTION
powerlevel10k has been moved to core in c6a99098f74f194b58f10338f2154aa2a1d7e19a but this file has remained causing somewhat irritating message to come up every time zsh starts up ;-)