### PR TITLE
Add lazy-load module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "fzy/external"]
 	path = fzy/external
 	url = https://github.com/aperezdc/zsh-fzy.git
+[submodule "lazy-load"]
+	path = lazy-load
+	url = https://github.com/xcv58/zsh-lazy-load.git


### PR DESCRIPTION
A preliminary performance comparison between native nvm and lazy load:

Native nvm/node module, https://github.com/xcv58/prezto-1/pull/1/files:
```
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.34s system 106% cpu 0.629 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.34s system 106% cpu 0.626 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.33s system 105% cpu 0.617 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.33s system 105% cpu 0.623 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.33s system 106% cpu 0.623 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.34s system 106% cpu 0.630 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.34s system 106% cpu 0.632 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.34s user 0.34s system 106% cpu 0.638 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.33s user 0.33s system 105% cpu 0.632 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.34s user 0.35s system 106% cpu 0.644 total
```

Lazy load for nvm, https://github.com/xcv58/prezto-1/pull/2/files:
```
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.04s user 0.03s system 86% cpu 0.073 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.03s user 0.02s system 96% cpu 0.055 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.04s user 0.03s system 96% cpu 0.065 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.04s user 0.02s system 96% cpu 0.062 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.04s user 0.03s system 97% cpu 0.065 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.03s user 0.02s system 96% cpu 0.056 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.03s user 0.02s system 95% cpu 0.061 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.04s user 0.02s system 96% cpu 0.063 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.03s user 0.02s system 96% cpu 0.061 total
~ ❯❯❯ time zsh -i -c exit
zsh -i -c exit  0.03s user 0.02s system 96% cpu 0.059 total
```