### PR TITLE
Add module for todo-txt

### DIFF
--- a/todo-txt/init.zsh
+++ b/todo-txt/init.zsh
@@ -1,0 +1,23 @@
+#
+# Defines todo.txt aliases
+#
+# Authors:
+#   Martin Zeman <martin.zeman@pm.me>
+#
+
+# Return if requirements are not found.
+if (( ! $+commands[todo.sh] )); then
+    return 1
+fi
+
+alias todo='todo.sh'
+
+alias tls='todo -c list'
+alias tla='todo -c listall'
+alias tadd='todo -t add'
+alias tato='todo -t addto'
+alias trm='todo del'
+alias tmv='todo move'
+alias tpre='todo prepend'
+alias tapp='todo append'
+alias tpri='todo pri'


### PR DESCRIPTION
Add useful aliases for todo-txt.

We can also include alias `t` recommended in https://github.com/todotxt/todo.txt-cli/wiki/tips-and-tricks, if you agree @belak.