### PR TITLE
Add completion for dotnet

### DIFF
--- a/dotnet-completion/README.md
+++ b/dotnet-completion/README.md
@@ -1,0 +1,3 @@
+# `dotnet` CLI Completion
+
+Adds the completion handler for `dotnet` to the CLI, which can complete command names, paths, NuGet packages, and more. For a full reference, see https://docs.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#zsh.

--- a/dotnet-completion/init.zsh
+++ b/dotnet-completion/init.zsh
@@ -1,0 +1,10 @@
+# zsh parameter completion for the dotnet CLI
+
+_dotnet_zsh_complete()
+{
+  local completions=("$(dotnet complete "$words")")
+
+  reply=( "${(ps:\n:)completions}" )
+}
+
+compctl -K _dotnet_zsh_complete dotnet

--- a/dotnet-completion/init.zsh
+++ b/dotnet-completion/init.zsh
@@ -1,10 +1,20 @@
 # zsh parameter completion for the dotnet CLI
+#
+# Originally from https://learn.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#zsh
 
-_dotnet_zsh_complete()
+_dotnet_zsh_complete() 
 {
   local completions=("$(dotnet complete "$words")")
 
-  reply=( "${(ps:\n:)completions}" )
+  # If the completion list is empty, just continue with filename selection
+  if [ -z "$completions" ]
+  then
+    _arguments '*::arguments: _normal'
+    return
+  fi
+
+  # This is not a variable assigment, don't remove spaces!
+  _values = "${(ps:\n:)completions}"
 }
 
-compctl -K _dotnet_zsh_complete dotnet
+compdef _dotnet_zsh_complete dotnet


### PR DESCRIPTION
Adds the completion handler for `dotnet`, as detailed in the [instructions](https://docs.microsoft.com/en-us/dotnet/core/tools/enable-tab-autocomplete#zsh).